### PR TITLE
1.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file.
 
+## [1.2.1] - 09-11-2025
+
+### Fix
+
+- Replace proposed API usage (`workspace.encode`/`workspace.decode`) with standard JavaScript `TextEncoder`/`TextDecoder` for better compatibility with VS Code forks like Cursor IDE - Thanks for reporting to [@Vadim-Kul](https://github.com/Vadim-Kul)
+
 ## [1.2.0] - 09-11-2025
 
 ### Added

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "tab-stack",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "tab-stack",
-      "version": "1.2.0",
+      "version": "1.2.1",
       "dependencies": {
         "@vscode/debugadapter": "^1.68.0",
         "@vscode/debugprotocol": "^1.68.0",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "email": "soerenwehmeier@googlemail.com"
   },
   "icon": "icon.png",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "repository": {
     "type": "git",
     "url": "git@github.com:ayecue/tab-stack.git"

--- a/src/handlers/webview.ts
+++ b/src/handlers/webview.ts
@@ -66,7 +66,7 @@ export class WebviewHandler implements Disposable {
     const jsWebviewUri = this._view.webview.asWebviewUri(jsUri);
 
     const htmlData = await workspace.fs.readFile(htmlUri);
-    let html = await workspace.decode(htmlData);
+    let html = new TextDecoder().decode(htmlData);
 
     html = html.replace('{{CSS_URI}}', cssWebviewUri.toString());
     html = html.replace('{{JS_URI}}', jsWebviewUri.toString());

--- a/src/services/tab-manager.ts
+++ b/src/services/tab-manager.ts
@@ -370,7 +370,7 @@ export class TabManagerService implements ITabManagerService {
     if (!this._stateHandler) return;
 
     const fileContent = this._stateHandler.exportStateFile();
-    const data = await workspace.encode(JSON.stringify(fileContent, null, 2));
+    const data = new TextEncoder().encode(JSON.stringify(fileContent, null, 2));
     await workspace.fs.writeFile(Uri.parse(exportUri), data);
     this.notify(
       ExtensionNotificationKind.Info,
@@ -386,7 +386,7 @@ export class TabManagerService implements ITabManagerService {
 
     try {
       fileContent = JSON.parse(
-        await workspace.decode(data)
+        new TextDecoder().decode(data)
       ) as TabStateFileContent;
     } catch {
       this.notify(

--- a/src/stores/file.ts
+++ b/src/stores/file.ts
@@ -143,7 +143,7 @@ export async function load(
 
 async function loadFile(location: string): Promise<TabStateFileContent | null> {
   const fileContent = await workspace.fs.readFile(Uri.file(location));
-  const data = migrate(JSON.parse(await workspace.decode(fileContent)));
+  const data = migrate(JSON.parse(new TextDecoder().decode(fileContent)));
   return data;
 }
 
@@ -151,6 +151,6 @@ async function saveFile(
   location: string,
   data: TabStateFileContent
 ): Promise<void> {
-  const fileContent = await workspace.encode(JSON.stringify(data));
+  const fileContent = new TextEncoder().encode(JSON.stringify(data));
   await workspace.fs.writeFile(Uri.file(location), fileContent);
 }


### PR DESCRIPTION
### Fix

- Replace proposed API usage (`workspace.encode`/`workspace.decode`) with standard JavaScript `TextEncoder`/`TextDecoder` for better compatibility with VS Code forks like Cursor IDE - https://github.com/ayecue/tab-stack/issues/12