### PR TITLE
Restore Cursor plan and canvas tabs from Unknown inputs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,20 @@
 
 All notable changes to this project will be documented in this file.
 
+## [Unreleased]
+
+### Added
+
+- **Cursor plan restore**: Persist URI/viewType for unrecognized editor inputs (Cursor `markdownPlan` / canvas) and restore file-backed `*.plan.md` via `vscode.openWith` (`workbench.editor.markdownPlan`)
+- **Cursor canvas restore**: Same path for `cursor-canvas:` / `workbench.editor.canvas` when a URI is available
+- **Debug command**: `Tab Stack: Dump Open Tab Inputs (Debug)` to inspect open tab input shapes
+- Default `tabRecoveryMappings` entries for `.plan.md` and `cursor-canvas:` URIs
+
+### Fix
+
+- **Recovery match fields**: `match.uri` and `match.viewType` in `tabStack.tabRecoveryMappings` now work (previously only base TabInfo fields were readable)
+- **Virtual `cursor-plan:`**: Best-effort resolve to `~/.cursor/plans` or workspace `.cursor/plans` before openWith; skip cleanly if no file exists
+
 ## [1.3.1] - 07-04-2026
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -210,6 +210,11 @@
         "icon": "$(search)"
       },
       {
+        "command": "tabStack.dumpOpenTabInputs",
+        "title": "Dump Open Tab Inputs (Debug)",
+        "category": "Tab Stack"
+      },
+      {
         "command": "tabStack.recentSnapshots",
         "title": "Restore Recent Snapshot",
         "category": "Tab Stack",
@@ -551,9 +556,41 @@
             "^Release Notes: [0-9.]+$": {
               "command": "update.showCurrentReleaseNotes",
               "unique": true
+            },
+            "cursorMarkdownPlanByUri": {
+              "command": "vscode.openWith",
+              "args": [
+                "{{uri}}",
+                "workbench.editor.markdownPlan",
+                {
+                  "viewColumn": "{{viewColumn}}",
+                  "preview": false
+                }
+              ],
+              "unique": true,
+              "match": {
+                "label": ".*",
+                "uri": ".*\\.plan\\.md(\\?.*)?$"
+              }
+            },
+            "cursorCanvasByUri": {
+              "command": "vscode.openWith",
+              "args": [
+                "{{uri}}",
+                "workbench.editor.canvas",
+                {
+                  "viewColumn": "{{viewColumn}}",
+                  "preview": false
+                }
+              ],
+              "unique": true,
+              "match": {
+                "label": ".*",
+                "uri": "^cursor-canvas:"
+              }
             }
           },
-          "description": "Mapping of identifiers to recovery commands for unknown tab types. Keys serve as identifiers (or as label regex patterns for backward compatibility). Values are either a command ID string (key is the label pattern) or an object with 'command', optional 'match' (regex criteria including 'label'), optional 'args', and optional 'nextTickDelay'.",
+          "description": "Mapping of identifiers to recovery commands for unknown tab types. Keys serve as identifiers (or as label regex patterns for backward compatibility). Values are either a command ID string (key is the label pattern) or an object with 'command', optional 'match' (regex criteria including 'label'), optional 'args', and optional 'nextTickDelay'. Cursor plan/canvas tabs are also restored in code via vscode.openWith when a URI is persisted.",
           "patternProperties": {
             ".*": {
               "oneOf": [

--- a/src/create-commands.ts
+++ b/src/create-commands.ts
@@ -697,6 +697,64 @@ export function createCommands(
     quickSlotCommands.push(quickSlotCommand);
   }
 
+  const dumpOpenTabInputsCommand = commands.registerCommand(
+    `${EXTENSION_NAME}.dumpOpenTabInputs`,
+    async () => {
+      const { transformTabToTabInfo } = await import('./transformers/tab');
+      const { extractUnknownTabIdentity } = await import(
+        './utils/unknown-tab-identity'
+      );
+      const { inferCursorEditorViewType } = await import(
+        './utils/cursor-editors'
+      );
+      const rows: Record<string, unknown>[] = [];
+
+      for (const group of window.tabGroups.all) {
+        group.tabs.forEach((tab, index) => {
+          const input = tab.input as unknown;
+          const identity = extractUnknownTabIdentity(input);
+          const transformed = transformTabToTabInfo(tab, group, index);
+          const ctorName =
+            input && typeof input === 'object'
+              ? (input as { constructor?: { name?: string } }).constructor
+                  ?.name
+              : typeof input;
+          const transformedUri =
+            'uri' in transformed ? transformed.uri : undefined;
+          const transformedViewType =
+            'viewType' in transformed ? transformed.viewType : undefined;
+          rows.push({
+            label: tab.label,
+            viewColumn: group.viewColumn,
+            index,
+            inputConstructor: ctorName,
+            inputKeys:
+              input && typeof input === 'object'
+                ? Object.keys(input as object)
+                : [],
+            duckUri: identity.uri,
+            duckViewType: identity.viewType,
+            transformedKind: transformed.kind,
+            transformedUri,
+            transformedViewType,
+            inferredCursorEditor: inferCursorEditorViewType({
+              uri: transformedUri,
+              viewType: transformedViewType,
+              label: tab.label
+            })
+          });
+        });
+      }
+
+      const text = JSON.stringify(rows, null, 2);
+      const doc = await workspace.openTextDocument({
+        content: text,
+        language: 'json'
+      });
+      await window.showTextDocument(doc, { preview: false });
+    }
+  );
+
   return [
     refreshCommand,
     quickSwitchCommand,
@@ -718,6 +776,7 @@ export function createCommands(
     clearAllTabsCommand,
     exportGroupCommand,
     importGroupCommand,
+    dumpOpenTabInputsCommand,
     ...quickSlotCommands
   ];
 }

--- a/src/handlers/tab-active-state.ts
+++ b/src/handlers/tab-active-state.ts
@@ -28,6 +28,7 @@ import {
   TabState
 } from '../types/tabs';
 import { focusTabInGroup, pinEditor } from '../utils/commands';
+import { inferCursorEditorViewType } from '../utils/cursor-editors';
 import { createSelectionRange, createTabKey, createTabKeyByViewColumn } from '../utils/tab-utils';
 import { updatedDiff } from 'deep-object-diff';
 import { TabFactory } from './tab-factory';
@@ -450,6 +451,25 @@ export class TabActiveStateHandler implements Disposable {
   }
 
   isTabRecoverable(tab: TabInfo): boolean {
+    // Cursor plan/canvas with a persisted URI can be reopened via openWith.
+    const uri = 'uri' in tab && typeof tab.uri === 'string' ? tab.uri : undefined;
+    const viewType =
+      'viewType' in tab && typeof tab.viewType === 'string'
+        ? tab.viewType
+        : undefined;
+    if (
+      inferCursorEditorViewType({
+        uri,
+        viewType,
+        label: tab.label
+      }) != null &&
+      uri
+    ) {
+      // Virtual cursor-plan: is best-effort; still mark recoverable so UI is honest
+      // that we will attempt restore (may no-op if file missing).
+      return true;
+    }
+
     // Check if tab kind is recoverable
     switch (tab.kind) {
       case TabKind.TabInputText:

--- a/src/handlers/tab-creation-task.ts
+++ b/src/handlers/tab-creation-task.ts
@@ -369,3 +369,87 @@ export class TabCreationTaskCustomCommand extends TabCreationTask {
     return `unknown tab "${this._tabInfo.label}" in column ${this._tabInfo.viewColumn} using recovery command "${this._command}"`;
   }
 }
+
+/**
+ * Open Cursor plan/canvas (or similar) via vscode.openWith, with optional
+ * resolution of virtual cursor-plan: URIs to on-disk .plan.md files.
+ */
+export class TabCreationTaskCursorEditorOpenWith extends TabCreationTask {
+  private _label: string;
+  private _uri: string;
+  private _viewType: string;
+  private _viewColumn: number | undefined;
+  private _resolvePlanUri: boolean;
+  private _log: ScopedLogger;
+
+  constructor(options: {
+    label: string;
+    uri: string;
+    viewType: string;
+    viewColumn: number | undefined;
+    resolvePlanUri?: boolean;
+  }) {
+    super();
+    this._label = options.label;
+    this._uri = options.uri;
+    this._viewType = options.viewType;
+    this._viewColumn = options.viewColumn;
+    this._resolvePlanUri = options.resolvePlanUri ?? false;
+    this._log = getLogger().child('TabCreationTaskCursorEditorOpenWith');
+  }
+
+  findRelatedTab(tabs: readonly Tab[]) {
+    return (
+      tabs.find(
+        (it) =>
+          it.label === this._label &&
+          it.group.viewColumn === this._viewColumn
+      ) ?? null
+    );
+  }
+
+  findExistingTab(allTabs: readonly Tab[]): Tab | null {
+    return (
+      allTabs.find(
+        (it) =>
+          it.label === this._label &&
+          it.group.viewColumn === this._viewColumn
+      ) ?? null
+    );
+  }
+
+  addEditorListener(_callback: (handle: AssociatedTabInstance) => void): {
+    dispose: () => void;
+  } {
+    return { dispose: () => {} };
+  }
+
+  async executeCommand() {
+    const { resolvePlanOpenUri } = await import('../utils/cursor-editors');
+    let openUri = Uri.parse(this._uri);
+
+    if (this._resolvePlanUri) {
+      const resolved = await resolvePlanOpenUri(this._uri);
+      if (resolved == null) {
+        this._log.warn(
+          `cannot resolve plan uri "${this._uri}" to a file-backed location; skip restore (save plan to disk to enable restore)`
+        );
+        return;
+      }
+      openUri = resolved;
+    }
+
+    this._log.debug(
+      `openWith ${this._viewType} uri=${openUri.toString()} column=${this._viewColumn}`
+    );
+    await commands.executeCommand('vscode.openWith', openUri, this._viewType, {
+      viewColumn: this._viewColumn,
+      preview: false,
+      preserveFocus: false
+    });
+  }
+
+  getDescription() {
+    return `cursor editor "${this._label}" uri "${this._uri}" viewType "${this._viewType}" in column ${this._viewColumn}`;
+  }
+}

--- a/src/handlers/tab-factory.ts
+++ b/src/handlers/tab-factory.ts
@@ -1,10 +1,47 @@
-import { window } from "vscode";
-import { OpenTabResult, TabInfo, TabInfoCustom, TabInfoNotebook, TabInfoNotebookDiff, TabInfoTerminal, TabInfoText, TabInfoTextDiff, TabKind } from "../types/tabs";
-import { getLogger, ScopedLogger } from "../services/logger";
-import { TabCreationTask, TabCreationTaskCustomCommand, TabCreationTaskTabInputCustom, TabCreationTaskTabInputNotebook, TabCreationTaskTabInputNotebookDiff, TabCreationTaskTabInputTerminal, TabCreationTaskTabInputText, TabCreationTaskTabInputTextDiff } from "./tab-creation-task";
-import { TabCreationOperation } from "../operations/tab-creation";
-import { TabOperation } from "../operations/tab-operation";
-import { TabRecoveryService } from "../services/tab-recovery-resolver";
+import { window } from 'vscode';
+import {
+  OpenTabResult,
+  TabInfo,
+  TabInfoCustom,
+  TabInfoNotebook,
+  TabInfoNotebookDiff,
+  TabInfoTerminal,
+  TabInfoText,
+  TabInfoTextDiff,
+  TabKind
+} from '../types/tabs';
+import { getLogger, ScopedLogger } from '../services/logger';
+import {
+  TabCreationTask,
+  TabCreationTaskCursorEditorOpenWith,
+  TabCreationTaskCustomCommand,
+  TabCreationTaskTabInputCustom,
+  TabCreationTaskTabInputNotebook,
+  TabCreationTaskTabInputNotebookDiff,
+  TabCreationTaskTabInputTerminal,
+  TabCreationTaskTabInputText,
+  TabCreationTaskTabInputTextDiff
+} from './tab-creation-task';
+import { TabCreationOperation } from '../operations/tab-creation';
+import { TabOperation } from '../operations/tab-operation';
+import { TabRecoveryService } from '../services/tab-recovery-resolver';
+import {
+  CURSOR_PLAN_EDITOR_ID,
+  CURSOR_PLAN_SCHEME,
+  inferCursorEditorViewType
+} from '../utils/cursor-editors';
+
+function getTabUri(tabInfo: TabInfo): string | undefined {
+  return 'uri' in tabInfo && typeof tabInfo.uri === 'string'
+    ? tabInfo.uri
+    : undefined;
+}
+
+function getTabViewType(tabInfo: TabInfo): string | undefined {
+  return 'viewType' in tabInfo && typeof tabInfo.viewType === 'string'
+    ? tabInfo.viewType
+    : undefined;
+}
 
 export class TabFactory {
   private _recoveryResolver: TabRecoveryService;
@@ -26,14 +63,50 @@ export class TabFactory {
       try {
         await task.execute();
       } catch (err) {
-        this._log.error(`unexpected error processing task: ${task.getDescription()}`, err);
+        this._log.error(
+          `unexpected error processing task: ${task.getDescription()}`,
+          err
+        );
       }
     }
 
     this._processing = false;
   }
 
+  /** Cursor plan/canvas restore when we have a URI and can infer the editor id. */
+  private _buildCursorEditorTask(tabInfo: TabInfo): TabCreationTask | null {
+    const uri = getTabUri(tabInfo);
+    if (!uri) {
+      return null;
+    }
+
+    const editorId = inferCursorEditorViewType({
+      uri,
+      viewType: getTabViewType(tabInfo),
+      label: tabInfo.label
+    });
+
+    if (!editorId) {
+      return null;
+    }
+
+    return new TabCreationTaskCursorEditorOpenWith({
+      label: tabInfo.label,
+      uri,
+      viewType: editorId,
+      viewColumn: tabInfo.viewColumn,
+      resolvePlanUri:
+        editorId === CURSOR_PLAN_EDITOR_ID &&
+        uri.startsWith(`${CURSOR_PLAN_SCHEME}:`)
+    });
+  }
+
   private _buildRawTask(tabInfo: TabInfo): TabCreationTask | null {
+    const cursorTask = this._buildCursorEditorTask(tabInfo);
+    if (cursorTask) {
+      return cursorTask;
+    }
+
     switch (tabInfo.kind) {
       case TabKind.TabInputText:
         return new TabCreationTaskTabInputText(tabInfo as TabInfoText);
@@ -44,18 +117,29 @@ export class TabFactory {
       case TabKind.TabInputNotebook:
         return new TabCreationTaskTabInputNotebook(tabInfo as TabInfoNotebook);
       case TabKind.TabInputNotebookDiff:
-        return new TabCreationTaskTabInputNotebookDiff(tabInfo as TabInfoNotebookDiff);
+        return new TabCreationTaskTabInputNotebookDiff(
+          tabInfo as TabInfoNotebookDiff
+        );
       case TabKind.TabInputTerminal:
         return new TabCreationTaskTabInputTerminal(tabInfo as TabInfoTerminal);
       case TabKind.TabInputWebview:
       case TabKind.Unknown:
-      default:
+      default: {
         const recovery = this._recoveryResolver.findMatch(tabInfo);
         if (recovery == null) {
-          this._log.warn(`no recovery command found for tab "${tabInfo.label}" of kind "${tabInfo.kind}"`);
+          this._log.warn(
+            `no recovery command found for tab "${tabInfo.label}" of kind "${tabInfo.kind}"`
+          );
           return null;
         }
-        return new TabCreationTaskCustomCommand(tabInfo, recovery.command, recovery.args, recovery.nextTickDelay, recovery.unique);
+        return new TabCreationTaskCustomCommand(
+          tabInfo,
+          recovery.command,
+          recovery.args,
+          recovery.nextTickDelay,
+          recovery.unique
+        );
+      }
     }
   }
 
@@ -71,11 +155,19 @@ export class TabFactory {
     }
 
     const tabGroup = window.tabGroups.all[tabInfo.viewColumn - 1];
-    const existingTab = tabGroup ? rawTask.findExistingTab(tabGroup.tabs) : undefined;
+    const existingTab = tabGroup
+      ? rawTask.findExistingTab(tabGroup.tabs)
+      : undefined;
 
     if (existingTab) {
-      this._log.info(`tab already exists: "${existingTab.label}" in column ${existingTab.group.viewColumn}, skipping creation`);
-      return Promise.resolve({ success: true, handle: null, tab: existingTab });
+      this._log.info(
+        `tab already exists: "${existingTab.label}" in column ${existingTab.group.viewColumn}, skipping creation`
+      );
+      return Promise.resolve({
+        success: true,
+        handle: null,
+        tab: existingTab
+      });
     }
 
     const creationOp = new TabCreationOperation(rawTask);

--- a/src/services/tab-recovery-resolver.ts
+++ b/src/services/tab-recovery-resolver.ts
@@ -7,11 +7,12 @@ import {
   RecoveryCommandResult,
   TabRecoveryMapping
 } from '../types/config';
-import { TabInfo, TabInfoBase } from '../types/tabs';
+import { TabInfo } from '../types/tabs';
 import { CompiledArgTemplate, CompiledMapping, CompiledMatchField } from '../types/tab-recovery';
 
 export class TabRecoveryService implements Disposable {
-  static readonly tabInfoFields: Set<keyof TabInfoBase> = new Set([
+  /** Base TabInfo fields plus optional identity fields used by Unknown/Custom tabs. */
+  static readonly tabInfoFields: Set<string> = new Set([
     'id',
     'label',
     'kind',
@@ -20,7 +21,12 @@ export class TabRecoveryService implements Disposable {
     'isDirty',
     'index',
     'viewColumn',
-    'isRecoverable'
+    'isRecoverable',
+    'uri',
+    'viewType',
+    'originalUri',
+    'modifiedUri',
+    'notebookType'
   ]);
 
   private _configService: ConfigService;
@@ -152,12 +158,15 @@ export class TabRecoveryService implements Disposable {
     return false;
   }
 
-  private _extractField(tabInfo: TabInfo, field: string): TabInfoBase[keyof Omit<TabInfoBase, 'meta'>] | null {
-    if (!TabRecoveryService.tabInfoFields.has(field as keyof TabInfoBase)) {
-      this._log.warn(`invalid match field "${field}" in recovery mapping: not a valid TabInfo property`);
+  private _extractField(tabInfo: TabInfo, field: string): unknown {
+    if (!TabRecoveryService.tabInfoFields.has(field)) {
+      this._log.warn(
+        `invalid match field "${field}" in recovery mapping: not a valid TabInfo property`
+      );
       return null;
     }
-    return tabInfo[field as keyof Omit<TabInfoBase, 'meta'>] ?? null;
+    const value = (tabInfo as TabInfo & Record<string, unknown>)[field];
+    return value ?? null;
   }
 
   private _matchesFields(fields: CompiledMatchField[], tabInfo: TabInfo): boolean {

--- a/src/transformers/tab.ts
+++ b/src/transformers/tab.ts
@@ -12,6 +12,12 @@ import {
 } from 'vscode';
 
 import { TabInfo, TabInfoBase, TabKind } from '../types/tabs';
+import { extractUnknownTabIdentity } from '../utils/unknown-tab-identity';
+import { inferCursorEditorViewType } from '../utils/cursor-editors';
+
+function isTabInput<T>(input: unknown, ctor: abstract new (...args: never[]) => T): input is T {
+  return typeof ctor === 'function' && input instanceof ctor;
+}
 
 export function transformTabToTabInfo(
   tab: Tab,
@@ -31,14 +37,14 @@ export function transformTabToTabInfo(
     meta: { type: 'unknown' }
   };
 
-  if (tab.input instanceof TabInputText) {
+  if (isTabInput(tab.input, TabInputText)) {
     return {
       ...base,
       uri: tab.input.uri.toString(),
       kind: TabKind.TabInputText,
       meta: { type: 'textEditor' }
     };
-  } else if (tab.input instanceof TabInputTextDiff) {
+  } else if (isTabInput(tab.input, TabInputTextDiff)) {
     return {
       ...base,
       originalUri: tab.input.original.toString(),
@@ -46,7 +52,7 @@ export function transformTabToTabInfo(
       kind: TabKind.TabInputTextDiff,
       meta: { type: 'textEditor' }
     };
-  } else if (tab.input instanceof TabInputCustom) {
+  } else if (isTabInput(tab.input, TabInputCustom)) {
     return {
       ...base,
       uri: tab.input.uri.toString(),
@@ -54,14 +60,14 @@ export function transformTabToTabInfo(
       kind: TabKind.TabInputCustom,
       meta: { type: 'textEditor' }
     };
-  } else if (tab.input instanceof TabInputWebview) {
+  } else if (isTabInput(tab.input, TabInputWebview)) {
     return {
       ...base,
       viewType: tab.input.viewType,
       kind: TabKind.TabInputWebview,
       meta: { type: 'unknown' }
     };
-  } else if (tab.input instanceof TabInputNotebook) {
+  } else if (isTabInput(tab.input, TabInputNotebook)) {
     return {
       ...base,
       uri: tab.input.uri.toString(),
@@ -69,7 +75,7 @@ export function transformTabToTabInfo(
       kind: TabKind.TabInputNotebook,
       meta: { type: 'notebookEditor' }
     };
-  } else if (tab.input instanceof TabInputNotebookDiff) {
+  } else if (isTabInput(tab.input, TabInputNotebookDiff)) {
     return {
       ...base,
       originalUri: tab.input.original.toString(),
@@ -78,7 +84,7 @@ export function transformTabToTabInfo(
       kind: TabKind.TabInputNotebookDiff,
       meta: { type: 'notebookEditor' }
     };
-  } else if (tab.input instanceof TabInputTerminal) {
+  } else if (isTabInput(tab.input, TabInputTerminal)) {
     return {
       ...base,
       kind: TabKind.TabInputTerminal,
@@ -86,5 +92,20 @@ export function transformTabToTabInfo(
     };
   }
 
-  return base;
+  const identity = extractUnknownTabIdentity(tab.input);
+  const inferredViewType = inferCursorEditorViewType({
+    uri: identity.uri,
+    viewType: identity.viewType,
+    label: tab.label
+  });
+
+  return {
+    ...base,
+    kind: TabKind.Unknown,
+    ...(identity.uri ? { uri: identity.uri } : {}),
+    ...(identity.viewType || inferredViewType
+      ? { viewType: identity.viewType ?? inferredViewType }
+      : {}),
+    meta: { type: 'unknown' }
+  };
 }

--- a/src/types/tabs.ts
+++ b/src/types/tabs.ts
@@ -106,15 +106,22 @@ export interface TabInfoTerminal extends TabInfoBase {
   readonly kind: TabKind.TabInputTerminal;
 }
 
+/** Unrecognized editor input (e.g. Cursor markdownPlan / canvas) with optional reopen identity. */
+export interface TabInfoUnknown extends TabInfoBase {
+  readonly kind: TabKind.Unknown;
+  readonly uri?: string;
+  readonly viewType?: string;
+}
+
 export type TabInfo =
-  | TabInfoBase
   | TabInfoText
   | TabInfoTextDiff
   | TabInfoCustom
   | TabInfoWebview
   | TabInfoNotebook
   | TabInfoNotebookDiff
-  | TabInfoTerminal;
+  | TabInfoTerminal
+  | TabInfoUnknown;
 
 export interface TabGroupInfo {
   readonly tabs: TabInfo[];

--- a/src/utils/cursor-editors.ts
+++ b/src/utils/cursor-editors.ts
@@ -1,0 +1,127 @@
+import * as os from 'os';
+import * as path from 'path';
+import { Uri, workspace } from 'vscode';
+
+/** Cursor built-in plan editor (workbench.editor.markdownPlan). */
+export const CURSOR_PLAN_EDITOR_ID = 'workbench.editor.markdownPlan';
+
+/** Cursor built-in canvas editor. */
+export const CURSOR_CANVAS_EDITOR_ID = 'workbench.editor.canvas';
+
+export const CURSOR_PLAN_SCHEME = 'cursor-plan';
+export const CURSOR_CANVAS_SCHEME = 'cursor-canvas';
+
+export function isPlanUri(uriString: string | undefined): boolean {
+  if (!uriString) {
+    return false;
+  }
+  try {
+    const uri = Uri.parse(uriString);
+    const fileName = path.basename(uri.path).toLowerCase();
+    if (fileName.endsWith('.plan.md')) {
+      return true;
+    }
+    return uri.scheme === CURSOR_PLAN_SCHEME;
+  } catch {
+    return false;
+  }
+}
+
+export function isCanvasUri(uriString: string | undefined): boolean {
+  if (!uriString) {
+    return false;
+  }
+  try {
+    return Uri.parse(uriString).scheme === CURSOR_CANVAS_SCHEME;
+  } catch {
+    return false;
+  }
+}
+
+export function isPlanViewType(viewType: string | undefined): boolean {
+  if (!viewType) {
+    return false;
+  }
+  return (
+    viewType === CURSOR_PLAN_EDITOR_ID ||
+    viewType === 'workbench.input.markdownPlan' ||
+    viewType === 'markdownPlanEditor'
+  );
+}
+
+export function isCanvasViewType(viewType: string | undefined): boolean {
+  if (!viewType) {
+    return false;
+  }
+  return (
+    viewType === CURSOR_CANVAS_EDITOR_ID ||
+    viewType === 'workbench.input.canvas'
+  );
+}
+
+/**
+ * Prefer a file-backed URI for plan restore. Virtual `cursor-plan:` tabs are not
+ * serialized by Cursor itself; best-effort resolve to ~/.cursor/plans or workspace.
+ */
+export async function resolvePlanOpenUri(
+  uriString: string
+): Promise<Uri | null> {
+  let uri: Uri;
+  try {
+    uri = Uri.parse(uriString);
+  } catch {
+    return null;
+  }
+
+  if (uri.scheme === 'file' || uri.scheme === 'vscode-userdata') {
+    return uri;
+  }
+
+  if (uri.scheme !== CURSOR_PLAN_SCHEME) {
+    return null;
+  }
+
+  const baseName = path.basename(uri.path);
+  if (!baseName.toLowerCase().endsWith('.plan.md')) {
+    return null;
+  }
+
+  const candidates: Uri[] = [];
+
+  const globalPlans = path.join(os.homedir(), '.cursor', 'plans', baseName);
+  candidates.push(Uri.file(globalPlans));
+
+  for (const folder of workspace.workspaceFolders ?? []) {
+    candidates.push(Uri.joinPath(folder.uri, '.cursor', 'plans', baseName));
+    candidates.push(Uri.joinPath(folder.uri, baseName));
+  }
+
+  for (const candidate of candidates) {
+    try {
+      await workspace.fs.stat(candidate);
+      return candidate;
+    } catch {
+      // try next
+    }
+  }
+
+  return null;
+}
+
+export function inferCursorEditorViewType(options: {
+  uri?: string;
+  viewType?: string;
+  label?: string;
+}): string | undefined {
+  if (isPlanViewType(options.viewType) || isPlanUri(options.uri)) {
+    return CURSOR_PLAN_EDITOR_ID;
+  }
+  if (isCanvasViewType(options.viewType) || isCanvasUri(options.uri)) {
+    return CURSOR_CANVAS_EDITOR_ID;
+  }
+  // Label-only heuristic for plan files opened without a parseable uri on input
+  if (options.label?.toLowerCase().endsWith('.plan.md')) {
+    return CURSOR_PLAN_EDITOR_ID;
+  }
+  return undefined;
+}

--- a/src/utils/unknown-tab-identity.ts
+++ b/src/utils/unknown-tab-identity.ts
@@ -1,0 +1,92 @@
+import { Uri } from 'vscode';
+
+export interface UnknownTabIdentity {
+  uri?: string;
+  viewType?: string;
+}
+
+function looksLikeUriString(value: string): boolean {
+  return (
+    value.startsWith('/') ||
+    value.startsWith('file:') ||
+    value.includes('://') ||
+    /^[a-zA-Z][a-zA-Z0-9+.-]*:/.test(value)
+  );
+}
+
+function asUriString(value: unknown): string | undefined {
+  if (Uri.isUri?.(value) || value instanceof Uri) {
+    return (value as Uri).toString();
+  }
+  if (typeof value === 'string' && value.length > 0 && looksLikeUriString(value)) {
+    return value;
+  }
+  if (value && typeof value === 'object') {
+    const record = value as {
+      scheme?: string;
+      path?: string;
+      toString?: () => string;
+    };
+    if (typeof record.scheme === 'string' && typeof record.path === 'string') {
+      try {
+        return Uri.from({
+          scheme: record.scheme,
+          path: record.path,
+          authority: (record as { authority?: string }).authority,
+          query: (record as { query?: string }).query,
+          fragment: (record as { fragment?: string }).fragment
+        }).toString();
+      } catch {
+        const authority = (record as { authority?: string }).authority ?? '';
+        return authority
+          ? `${record.scheme}://${authority}${record.path}`
+          : `${record.scheme}:${record.path}`;
+      }
+    }
+    if (typeof record.toString === 'function') {
+      const asString = String(record.toString());
+      if (looksLikeUriString(asString)) {
+        return asString;
+      }
+    }
+  }
+  return undefined;
+}
+
+/**
+ * Duck-type unrecognized tab.input objects (e.g. Cursor built-in editors that
+ * are not TabInputText/Custom/…). Prefer resource/uri and editor/view type ids.
+ */
+export function extractUnknownTabIdentity(input: unknown): UnknownTabIdentity {
+  if (input == null || typeof input !== 'object') {
+    return {};
+  }
+
+  const record = input as Record<string, unknown>;
+  const uri =
+    asUriString(record.uri) ??
+    asUriString(record.resource) ??
+    asUriString(record.modified) ??
+    asUriString(record.original);
+
+  const viewTypeCandidate =
+    record.viewType ??
+    record.editorId ??
+    record.typeId ??
+    (typeof record.get === 'function' ? undefined : undefined);
+
+  let viewType: string | undefined;
+  if (typeof viewTypeCandidate === 'string' && viewTypeCandidate.length > 0) {
+    viewType = viewTypeCandidate;
+  } else {
+    // Some EditorInput subclasses expose static TypeID/EditorID on the constructor.
+    const ctor = (input as { constructor?: { EditorID?: string; TypeID?: string } }).constructor;
+    if (typeof ctor?.EditorID === 'string' && ctor.EditorID.length > 0) {
+      viewType = ctor.EditorID;
+    } else if (typeof ctor?.TypeID === 'string' && ctor.TypeID.length > 0) {
+      viewType = ctor.TypeID;
+    }
+  }
+
+  return { uri, viewType };
+}

--- a/tests/__mocks__/vscode.ts
+++ b/tests/__mocks__/vscode.ts
@@ -24,6 +24,10 @@ class TabInputCustom {
   constructor(public uri: any, public viewType: string) {}
 }
 
+class TabInputWebview {
+  constructor(public viewType: string) {}
+}
+
 class TabInputTerminal {}
 
 // Enhance window mock to return proper disposable objects
@@ -42,6 +46,7 @@ const enhanced = {
   TabInputNotebook,
   TabInputNotebookDiff,
   TabInputCustom,
+  TabInputWebview,
   TabInputTerminal,
 };
 
@@ -65,4 +70,12 @@ export const {
 } = vscode;
 
 export const window = enhancedWindow;
-export { TabInputText, TabInputTextDiff, TabInputNotebook, TabInputNotebookDiff, TabInputCustom, TabInputTerminal };
+export {
+  TabInputText,
+  TabInputTextDiff,
+  TabInputNotebook,
+  TabInputNotebookDiff,
+  TabInputCustom,
+  TabInputWebview,
+  TabInputTerminal
+};

--- a/tests/unit/services/tab-recovery-resolver.test.ts
+++ b/tests/unit/services/tab-recovery-resolver.test.ts
@@ -1,0 +1,65 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+
+import { TabRecoveryService } from '../../../src/services/tab-recovery-resolver';
+import { TabKind } from '../../../src/types/tabs';
+import { MockConfigService } from '../../mocks';
+
+describe('TabRecoveryService match fields', () => {
+  let config: MockConfigService;
+  let service: TabRecoveryService;
+
+  beforeEach(() => {
+    config = new MockConfigService({
+      tabRecoveryMappings: {
+        cursorMarkdownPlanByUri: {
+          command: 'vscode.openWith',
+          args: ['{{uri}}', 'workbench.editor.markdownPlan'],
+          unique: true,
+          match: {
+            label: '.*',
+            uri: '.*\\.plan\\.md$'
+          }
+        }
+      }
+    });
+    service = new TabRecoveryService(config as any);
+  });
+
+  it('matches unknown tabs by uri field', () => {
+    const tab: any = {
+      id: '1',
+      label: 'demo.plan.md',
+      kind: TabKind.Unknown,
+      isActive: false,
+      isPinned: false,
+      index: 0,
+      viewColumn: 1,
+      isRecoverable: false,
+      uri: 'file:///tmp/demo.plan.md',
+      viewType: 'workbench.editor.markdownPlan',
+      meta: { type: 'unknown' }
+    };
+
+    expect(service.hasMatch(tab)).toBe(true);
+    const match = service.findMatch(tab);
+    expect(match?.command).toBe('vscode.openWith');
+    expect(match?.args?.[0]).toBe('file:///tmp/demo.plan.md');
+  });
+
+  it('does not match unrelated uris', () => {
+    const tab: any = {
+      id: '1',
+      label: 'foo.ts',
+      kind: TabKind.Unknown,
+      isActive: false,
+      isPinned: false,
+      index: 0,
+      viewColumn: 1,
+      isRecoverable: false,
+      uri: 'file:///tmp/foo.ts',
+      meta: { type: 'unknown' }
+    };
+
+    expect(service.hasMatch(tab)).toBe(false);
+  });
+});

--- a/tests/unit/transformers/unknown-tab.test.ts
+++ b/tests/unit/transformers/unknown-tab.test.ts
@@ -1,0 +1,82 @@
+import { describe, expect, it } from 'vitest';
+import type { Tab as VsCodeTab, TabGroup as VsCodeTabGroup } from 'vscode';
+import { Uri } from 'vscode';
+
+import { transformTabToTabInfo } from '../../../src/transformers/tab';
+import { TabKind } from '../../../src/types/tabs';
+
+const createGroup = (
+  overrides: Partial<VsCodeTabGroup> = {}
+): VsCodeTabGroup =>
+  ({
+    viewColumn: 1,
+    tabs: [] as unknown as readonly VsCodeTab[],
+    ...overrides
+  }) as VsCodeTabGroup;
+
+const createTab = (
+  input: unknown,
+  overrides: Partial<VsCodeTab> = {}
+): VsCodeTab =>
+  ({
+    label: 'demo.plan.md',
+    isActive: false,
+    isPinned: false,
+    isDirty: false,
+    isPreview: false,
+    input,
+    group: overrides.group ?? createGroup(),
+    ...overrides
+  }) as VsCodeTab;
+
+describe('transformTabToTabInfo unknown Cursor editors', () => {
+  it('persists uri and viewType for unrecognized plan-like inputs', () => {
+    class FakePlanInput {
+      static EditorID = 'workbench.editor.markdownPlan';
+      resource = Uri.file('/tmp/demo.plan.md');
+    }
+
+    const result = transformTabToTabInfo(
+      createTab(new FakePlanInput()),
+      createGroup(),
+      0
+    );
+
+    expect(result.kind).toBe(TabKind.Unknown);
+    expect(result).toMatchObject({
+      uri: Uri.file('/tmp/demo.plan.md').toString(),
+      viewType: 'workbench.editor.markdownPlan'
+    });
+  });
+
+  it('infers plan editor from .plan.md uri without viewType', () => {
+    const result = transformTabToTabInfo(
+      createTab({ resource: Uri.file('/tmp/other.plan.md') }),
+      createGroup(),
+      0
+    );
+
+    expect(result.kind).toBe(TabKind.Unknown);
+    expect(result).toMatchObject({
+      uri: Uri.file('/tmp/other.plan.md').toString(),
+      viewType: 'workbench.editor.markdownPlan'
+    });
+  });
+
+  it('persists cursor-canvas uri and infers canvas editor', () => {
+    const result = transformTabToTabInfo(
+      createTab(
+        { resource: Uri.parse('cursor-canvas:/welcome') },
+        { label: 'Canvas' }
+      ),
+      createGroup(),
+      0
+    );
+
+    expect(result.kind).toBe(TabKind.Unknown);
+    expect(result).toMatchObject({
+      uri: 'cursor-canvas:/welcome',
+      viewType: 'workbench.editor.canvas'
+    });
+  });
+});

--- a/tests/unit/utils/cursor-editors.test.ts
+++ b/tests/unit/utils/cursor-editors.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, it } from 'vitest';
+import { Uri } from 'vscode';
+
+import {
+  CURSOR_CANVAS_EDITOR_ID,
+  CURSOR_PLAN_EDITOR_ID,
+  inferCursorEditorViewType,
+  isCanvasUri,
+  isPlanUri,
+  resolvePlanOpenUri
+} from '../../../src/utils/cursor-editors';
+
+describe('cursor-editors', () => {
+  it('detects plan uris', () => {
+    expect(isPlanUri(Uri.file('/tmp/x.plan.md').toString())).toBe(true);
+    expect(isPlanUri('cursor-plan:/abc.plan.md')).toBe(true);
+    expect(isPlanUri(Uri.file('/tmp/x.ts').toString())).toBe(false);
+  });
+
+  it('detects canvas uris', () => {
+    expect(isCanvasUri('cursor-canvas:/welcome')).toBe(true);
+    expect(isCanvasUri(Uri.file('/tmp/x.ts').toString())).toBe(false);
+  });
+
+  it('infers plan and canvas editor ids', () => {
+    expect(
+      inferCursorEditorViewType({
+        uri: Uri.file('/tmp/demo.plan.md').toString()
+      })
+    ).toBe(CURSOR_PLAN_EDITOR_ID);
+
+    expect(
+      inferCursorEditorViewType({
+        viewType: 'workbench.editor.markdownPlan',
+        uri: Uri.file('/tmp/demo.plan.md').toString()
+      })
+    ).toBe(CURSOR_PLAN_EDITOR_ID);
+
+    expect(
+      inferCursorEditorViewType({
+        uri: 'cursor-canvas:/foo'
+      })
+    ).toBe(CURSOR_CANVAS_EDITOR_ID);
+
+    expect(
+      inferCursorEditorViewType({
+        label: 'my.plan.md'
+      })
+    ).toBe(CURSOR_PLAN_EDITOR_ID);
+
+    expect(
+      inferCursorEditorViewType({
+        uri: Uri.file('/tmp/foo.ts').toString(),
+        label: 'foo.ts'
+      })
+    ).toBeUndefined();
+  });
+
+  it('resolvePlanOpenUri returns file uris unchanged', async () => {
+    const fileUri = Uri.file('/tmp/demo.plan.md').toString();
+    const resolved = await resolvePlanOpenUri(fileUri);
+    expect(resolved?.toString()).toBe(fileUri);
+  });
+
+  it('resolvePlanOpenUri returns null for unknown virtual plans', async () => {
+    const resolved = await resolvePlanOpenUri(
+      'cursor-plan:/definitely-missing-xyz.plan.md'
+    );
+    expect(resolved).toBeNull();
+  });
+});

--- a/tests/unit/utils/unknown-tab-identity.test.ts
+++ b/tests/unit/utils/unknown-tab-identity.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from 'vitest';
+import { Uri } from 'vscode';
+
+import { extractUnknownTabIdentity } from '../../../src/utils/unknown-tab-identity';
+
+describe('extractUnknownTabIdentity', () => {
+  it('returns empty for nullish input', () => {
+    expect(extractUnknownTabIdentity(null)).toEqual({});
+    expect(extractUnknownTabIdentity(undefined)).toEqual({});
+  });
+
+  it('reads uri and viewType from a duck-typed custom-like input', () => {
+    expect(
+      extractUnknownTabIdentity({
+        uri: Uri.file('/tmp/foo.plan.md'),
+        viewType: 'workbench.editor.markdownPlan'
+      })
+    ).toEqual({
+      uri: Uri.file('/tmp/foo.plan.md').toString(),
+      viewType: 'workbench.editor.markdownPlan'
+    });
+  });
+
+  it('reads resource and constructor EditorID', () => {
+    class FakePlanInput {
+      static EditorID = 'workbench.editor.markdownPlan';
+      resource = Uri.file('/home/me/.cursor/plans/demo.plan.md');
+    }
+
+    expect(extractUnknownTabIdentity(new FakePlanInput())).toEqual({
+      uri: Uri.file('/home/me/.cursor/plans/demo.plan.md').toString(),
+      viewType: 'workbench.editor.markdownPlan'
+    });
+  });
+
+  it('reads canvas path via resource scheme', () => {
+    expect(
+      extractUnknownTabIdentity({
+        resource: Uri.parse('cursor-canvas:/my-canvas')
+      })
+    ).toEqual({
+      uri: 'cursor-canvas:/my-canvas',
+      viewType: undefined
+    });
+  });
+});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -15,7 +15,8 @@
     "skipLibCheck": true,
     "jsx": "react-jsx",
     "moduleResolution": "node",
-    "allowSyntheticDefaultImports": true
+    "allowSyntheticDefaultImports": true,
+    "ignoreDeprecations": "6.0"
   },
   "include": [
     "src/**/*"


### PR DESCRIPTION
## Summary

- Persist `uri`/`viewType` for unrecognized editor inputs so Cursor plan (`workbench.editor.markdownPlan`) and canvas (`workbench.editor.canvas`) tabs can be saved and restored via `vscode.openWith`
- Fix `tabStack.tabRecoveryMappings` so documented `match.uri` / `match.viewType` fields actually work
- Best-effort resolve virtual `cursor-plan:` URIs to on-disk plans; skip cleanly when none exist
- Add debug command `Tab Stack: Dump Open Tab Inputs` and unit coverage for the new paths

Closes #26

## Test plan

- [x] `npm run test:unit` (241 passed)
- [ ] F5 in Cursor: open file-backed `*.plan.md` → Dump Open Tab Inputs → URI + inferred plan editor
- [ ] Save group/snapshot → close all → restore → plan editor returns without red badge
- [ ] Virtual-only `cursor-plan:` with no disk file: restore no-ops cleanly
- [ ] Optional: canvas tab restores with `workbench.editor.canvas` when URI is present